### PR TITLE
Add PDDS and 3 audio tasks to STAGING_PROJECT

### DIFF
--- a/STAGING_PROJECT/protocol.json
+++ b/STAGING_PROJECT/protocol.json
@@ -556,13 +556,121 @@
         "estimatedCompletionTime": 4,
         "protocol": {
           "repeatProtocol": {
-            "unit": "day",
-            "amount": 1
+            "unit": "week",
+            "amount": 18
           },
           "repeatQuestionnaire": {
-            "unit": "min",
+            "unit": "hour",
             "unitsFromZero": [
-              720
+              12,
+              1356,
+              2364
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 4,
+            "repeat": 1
+          }
+        }
+      },
+      {
+        "name": "AUDIO_2",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/audio-test/questionnaires/",
+          "name": "audio_2",
+          "avsc": "questionnaire"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 4,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "week",
+            "amount": 18
+          },
+          "repeatQuestionnaire": {
+            "unit": "hour",
+            "unitsFromZero": [
+              348,
+              1020,
+              2700
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 4,
+            "repeat": 1
+          }
+        }
+      },
+      {
+        "name": "AUDIO_3",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/audio-test/questionnaires/",
+          "name": "audio_3",
+          "avsc": "questionnaire"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 4,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "week",
+            "amount": 18
+          },
+          "repeatQuestionnaire": {
+            "unit": "hour",
+            "unitsFromZero": [
+              684,
+              1692,
+              2028
             ]
           },
           "reminders": {

--- a/STAGING_PROJECT/protocol.json
+++ b/STAGING_PROJECT/protocol.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.9",
+    "version": "0.3.10",
     "schemaVersion": "0.0.2",
     "name": "RADAR STAGING Project",
     "healthIssues": [

--- a/STAGING_PROJECT/protocol.json
+++ b/STAGING_PROJECT/protocol.json
@@ -1,576 +1,632 @@
 {
-  "version": "0.3.9",
-  "schemaVersion": "0.0.2",
-  "name": "RADAR STAGING Project",
-  "healthIssues": [
-    "depression"
-  ],
-  "protocols": [
-    {
-      "name": "SAMPLE_INPUT_TYPE_DEMO",
-      "showIntroduction": false,
-      "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "sample-field-types",
-        "avsc": "task"
-      },
-      "startText": {
-        "en": "Welcome to testing tasks",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "endText": {
-        "en": "Thank you for taking the time today.",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "warn": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "estimatedCompletionTime": 2,
-      "protocol": {
-        "repeatProtocol": {
-          "unit": "day",
-          "amount": 1
+    "version": "0.3.9",
+    "schemaVersion": "0.0.2",
+    "name": "RADAR STAGING Project",
+    "healthIssues": [
+      "depression"
+    ],
+    "protocols": [
+      {
+        "name": "SAMPLE_INPUT_TYPE_DEMO",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "sample-field-types",
+          "avsc": "task"
         },
-        "repeatQuestionnaire": {
-          "unit": "min",
-          "unitsFromZero": [
-            1000
-          ]
+        "startText": {
+          "en": "Welcome to testing tasks",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
         },
-        "reminders": {
-          "unit": "day",
-          "amount": 0,
-          "repeat": 0
+        "endText": {
+          "en": "Thank you for taking the time today.",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
         },
-        "clinicalProtocol": {
-          "requiresInClinicCompletion": true,
-          "repeatAfterClinicVisit": {
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 2,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 1
+          },
+          "repeatQuestionnaire": {
             "unit": "min",
             "unitsFromZero": [
-              4
+              1000
             ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 0,
+            "repeat": 0
+          },
+          "clinicalProtocol": {
+            "requiresInClinicCompletion": true,
+            "repeatAfterClinicVisit": {
+              "unit": "min",
+              "unitsFromZero": [
+                4
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "ROMBERG",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "romberg_test",
+          "avsc": "task"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "Thank you for taking the time today.",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 2,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 1
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              1060
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 0,
+            "repeat": 0
+          },
+          "clinicalProtocol": {
+            "requiresInClinicCompletion": true,
+            "repeatAfterClinicVisit": {
+              "unit": "min",
+              "unitsFromZero": [
+                4
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "THINC-IT",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "thinc_it",
+          "avsc": "notification"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "Requires a quiet space.",
+          "it": "Richiede uno spazio tranquillo.",
+          "nl": "Vereist een rustige ruimte.",
+          "da": "Kræver et stille rum.",
+          "de": "Benötigt einen ruhigen Platz.",
+          "es": "Requiere un espacio tranquilo."
+        },
+        "estimatedCompletionTime": 1,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 1
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              660
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 0,
+            "repeat": 0
+          }
+        }
+      },
+      {
+        "name": "2MW",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "2MW_test",
+          "avsc": "task"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "Thank you for taking the time today.",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 2,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 1
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              1090
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 0,
+            "repeat": 0
+          },
+          "clinicalProtocol": {
+            "requiresInClinicCompletion": true,
+            "repeatAfterClinicVisit": {
+              "unit": "min",
+              "unitsFromZero": [
+                10
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "TANDEM WALKING",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "tandem_walking_test",
+          "avsc": "task"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 1,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 1
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              1120
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 0,
+            "repeat": 0
+          },
+          "clinicalProtocol": {
+            "requiresInClinicCompletion": true,
+            "repeatAfterClinicVisit": {
+              "unit": "min",
+              "unitsFromZero": [
+                1
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "PHQ8",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "phq8",
+          "avsc": "questionnaire"
+        },
+        "startText": {
+          "en": "This questionnaire is known as the PHQ8. Clinicians use it to assess current depression in patients. Please note that none of your answers will be collected today. Thank you for taking part in this focus group.",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "Thank you for taking the time today.",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 2,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 4
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              540
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 4,
+            "repeat": 1
+          },
+          "completionWindow": {
+            "unit": "day",
+            "amount": 3
+          }
+        }
+      },
+      {
+        "name": "RSES",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "rses",
+          "avsc": "questionnaire"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 4,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 4
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              600
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 4,
+            "repeat": 1
+          },
+          "completionWindow": {
+            "unit": "day",
+            "amount": 3
+          }
+        }
+      },
+      {
+        "name": "ESM",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "esm",
+          "avsc": "questionnaire"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 3,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 1
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              540,
+              600,
+              660,
+              720,
+              780,
+              840,
+              900,
+              960,
+              1020,
+              1080,
+              1140,
+              1200,
+              1260
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 0,
+            "repeat": 0
+          }
+        }
+      },
+      {
+        "name": "ESM_DEMO",
+        "showIntroduction": true,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "esm-demo",
+          "avsc": "questionnaire"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 3,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "year",
+            "amount": 9999
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              540
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 0,
+            "repeat": 0
+          }
+        }
+      },
+      {
+        "name": "AUDIO",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/audio-test/questionnaires/",
+          "name": "audio",
+          "avsc": "questionnaire"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 4,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 1
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              720
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 4,
+            "repeat": 1
+          }
+        }
+      },
+      {
+        "name": "PDDS",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/auto-update-dd/questionnaires/",
+          "name": "patient_determined_disease_step_3",
+          "avsc": "questionnaire"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 1,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 3
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              630
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 4,
+            "repeat": 1
+          },
+          "completionWindow": {
+            "unit": "day",
+            "amount": 3
           }
         }
       }
-    },
-    {
-      "name": "ROMBERG",
-      "showIntroduction": false,
-      "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "romberg_test",
-        "avsc": "task"
-      },
-      "startText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "endText": {
-        "en": "Thank you for taking the time today.",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "warn": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "estimatedCompletionTime": 2,
-      "protocol": {
-        "repeatProtocol": {
-          "unit": "day",
-          "amount": 1
-        },
-        "repeatQuestionnaire": {
-          "unit": "min",
-          "unitsFromZero": [
-            1060
-          ]
-        },
-        "reminders": {
-          "unit": "day",
-          "amount": 0,
-          "repeat": 0
-        },
-        "clinicalProtocol": {
-          "requiresInClinicCompletion": true,
-          "repeatAfterClinicVisit": {
-            "unit": "min",
-            "unitsFromZero": [
-              4
-            ]
-          }
-        }
-      }
-    },
-    {
-      "name": "THINC-IT",
-      "showIntroduction": false,
-      "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "thinc_it",
-        "avsc": "notification"
-      },
-      "startText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "endText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "warn": {
-        "en": "Requires a quiet space.",
-        "it": "Richiede uno spazio tranquillo.",
-        "nl": "Vereist een rustige ruimte.",
-        "da": "Kræver et stille rum.",
-        "de": "Benötigt einen ruhigen Platz.",
-        "es": "Requiere un espacio tranquilo."
-      },
-      "estimatedCompletionTime": 1,
-      "protocol": {
-        "repeatProtocol": {
-          "unit": "day",
-          "amount": 1
-        },
-        "repeatQuestionnaire": {
-          "unit": "min",
-          "unitsFromZero": [
-            660
-          ]
-        },
-        "reminders": {
-          "unit": "day",
-          "amount": 0,
-          "repeat": 0
-        }
-      }
-    },
-    {
-      "name": "2MW",
-      "showIntroduction": false,
-      "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "2MW_test",
-        "avsc": "task"
-      },
-      "startText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "endText": {
-        "en": "Thank you for taking the time today.",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "warn": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "estimatedCompletionTime": 2,
-      "protocol": {
-        "repeatProtocol": {
-          "unit": "day",
-          "amount": 1
-        },
-        "repeatQuestionnaire": {
-          "unit": "min",
-          "unitsFromZero": [
-            1090
-          ]
-        },
-        "reminders": {
-          "unit": "day",
-          "amount": 0,
-          "repeat": 0
-        },
-        "clinicalProtocol": {
-          "requiresInClinicCompletion": true,
-          "repeatAfterClinicVisit": {
-            "unit": "min",
-            "unitsFromZero": [
-              10
-            ]
-          }
-        }
-      }
-    },
-    {
-      "name": "TANDEM WALKING",
-      "showIntroduction": false,
-      "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "tandem_walking_test",
-        "avsc": "task"
-      },
-      "startText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "endText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "warn": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "estimatedCompletionTime": 1,
-      "protocol": {
-        "repeatProtocol": {
-          "unit": "day",
-          "amount": 1
-        },
-        "repeatQuestionnaire": {
-          "unit": "min",
-          "unitsFromZero": [
-            1120
-          ]
-        },
-        "reminders": {
-          "unit": "day",
-          "amount": 0,
-          "repeat": 0
-        },
-        "clinicalProtocol": {
-          "requiresInClinicCompletion": true,
-          "repeatAfterClinicVisit": {
-            "unit": "min",
-            "unitsFromZero": [
-              1
-            ]
-          }
-        }
-      }
-    },
-    {
-      "name": "PHQ8",
-      "showIntroduction": false,
-      "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "phq8",
-        "avsc": "questionnaire"
-      },
-      "startText": {
-        "en": "This questionnaire is known as the PHQ8. Clinicians use it to assess current depression in patients. Please note that none of your answers will be collected today. Thank you for taking part in this focus group.",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "endText": {
-        "en": "Thank you for taking the time today.",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "warn": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "estimatedCompletionTime": 2,
-      "protocol": {
-        "repeatProtocol": {
-          "unit": "day",
-          "amount": 4
-        },
-        "repeatQuestionnaire": {
-          "unit": "min",
-          "unitsFromZero": [
-            540
-          ]
-        },
-        "reminders": {
-          "unit": "day",
-          "amount": 4,
-          "repeat": 1
-        },
-        "completionWindow": {
-          "unit": "day",
-          "amount": 3
-        }
-      }
-    },
-    {
-      "name": "RSES",
-      "showIntroduction": false,
-      "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "rses",
-        "avsc": "questionnaire"
-      },
-      "startText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "endText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "warn": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "estimatedCompletionTime": 4,
-      "protocol": {
-        "repeatProtocol": {
-          "unit": "day",
-          "amount": 4
-        },
-        "repeatQuestionnaire": {
-          "unit": "min",
-          "unitsFromZero": [
-            600
-          ]
-        },
-        "reminders": {
-          "unit": "day",
-          "amount": 4,
-          "repeat": 1
-        },
-        "completionWindow": {
-          "unit": "day",
-          "amount": 3
-        }
-      }
-    },
-    {
-      "name": "ESM",
-      "showIntroduction": false,
-      "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "esm",
-        "avsc": "questionnaire"
-      },
-      "startText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "endText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "warn": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "estimatedCompletionTime": 3,
-      "protocol": {
-        "repeatProtocol": {
-          "unit": "day",
-          "amount": 1
-        },
-        "repeatQuestionnaire": {
-          "unit": "min",
-          "unitsFromZero": [
-            540,
-            600,
-            660,
-            720,
-            780,
-            840,
-            900,
-            960,
-            1020,
-            1080,
-            1140,
-            1200,
-            1260
-          ]
-        },
-        "reminders": {
-          "unit": "day",
-          "amount": 0,
-          "repeat": 0
-        }
-      }
-    },
-    {
-      "name": "ESM_DEMO",
-      "showIntroduction": true,
-      "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "esm-demo",
-        "avsc": "questionnaire"
-      },
-      "startText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "endText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "warn": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "estimatedCompletionTime": 3,
-      "protocol": {
-        "repeatProtocol": {
-          "unit": "year",
-          "amount": 9999
-        },
-        "repeatQuestionnaire": {
-          "unit": "min",
-          "unitsFromZero": [
-            540
-          ]
-        },
-        "reminders": {
-          "unit": "day",
-          "amount": 0,
-          "repeat": 0
-        }
-      }
-    },
-    {
-      "name": "AUDIO",
-      "showIntroduction": false,
-      "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/audio-test/questionnaires/",
-        "name": "audio",
-        "avsc": "questionnaire"
-      },
-      "startText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "endText": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "warn": {
-        "en": "",
-        "it": "",
-        "nl": "",
-        "da": "",
-        "de": "",
-        "es": ""
-      },
-      "estimatedCompletionTime": 4,
-      "protocol": {
-        "repeatProtocol": {
-          "unit": "day",
-          "amount": 1
-        },
-        "repeatQuestionnaire": {
-          "unit": "min",
-          "unitsFromZero": [
-            720
-          ]
-        },
-        "reminders": {
-          "unit": "day",
-          "amount": 4,
-          "repeat": 1
-        }
-      }
-    }
-  ]
-}
+    ]
+  }
+  

--- a/STAGING_PROJECT/protocol.json
+++ b/STAGING_PROJECT/protocol.json
@@ -685,7 +685,7 @@
         "showIntroduction": false,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/auto-update-dd/questionnaires/",
-          "name": "patient_determined_disease_step_3",
+          "name": "patient_determined_disease_step",
           "avsc": "questionnaire"
         },
         "startText": {

--- a/STAGING_PROJECT/protocol.json
+++ b/STAGING_PROJECT/protocol.json
@@ -7,7 +7,7 @@
     ],
     "protocols": [
       {
-        "name": "SAMPLE_INPUT_TYPE_DEMO",
+        "name": "SAMPLE_INPUT_DEMO",
         "showIntroduction": false,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
@@ -556,15 +556,15 @@
         "estimatedCompletionTime": 4,
         "protocol": {
           "repeatProtocol": {
-            "unit": "week",
-            "amount": 18
+            "unit": "day",
+            "amount": 9
           },
           "repeatQuestionnaire": {
             "unit": "hour",
             "unitsFromZero": [
               12,
-              1356,
-              2364
+              108,
+              180
             ]
           },
           "reminders": {
@@ -609,15 +609,15 @@
         "estimatedCompletionTime": 4,
         "protocol": {
           "repeatProtocol": {
-            "unit": "week",
-            "amount": 18
+            "unit": "day",
+            "amount": 9
           },
           "repeatQuestionnaire": {
             "unit": "hour",
             "unitsFromZero": [
-              348,
-              1020,
-              2700
+              36,
+              84,
+              204
             ]
           },
           "reminders": {
@@ -662,15 +662,15 @@
         "estimatedCompletionTime": 4,
         "protocol": {
           "repeatProtocol": {
-            "unit": "week",
-            "amount": 18
+            "unit": "day",
+            "amount": 9
           },
           "repeatQuestionnaire": {
             "unit": "hour",
             "unitsFromZero": [
-              684,
-              1692,
-              2028
+              60,
+              132,
+              156
             ]
           },
           "reminders": {
@@ -732,6 +732,57 @@
           "completionWindow": {
             "unit": "day",
             "amount": 3
+          }
+        }
+      },
+      {
+        "name": "PDQ",
+        "showIntroduction": false,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "perceived_deficits_questionnaire",
+          "avsc": "questionnaire"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 1,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "day",
+            "amount": 2
+          },
+          "repeatQuestionnaire": {
+            "unit": "min",
+            "unitsFromZero": [
+              600
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 0,
+            "repeat": 0
           }
         }
       }

--- a/STAGING_PROJECT/protocol.json
+++ b/STAGING_PROJECT/protocol.json
@@ -557,14 +557,12 @@
         "protocol": {
           "repeatProtocol": {
             "unit": "day",
-            "amount": 9
+            "amount": 3
           },
           "repeatQuestionnaire": {
             "unit": "hour",
             "unitsFromZero": [
-              12,
-              108,
-              180
+              12
             ]
           },
           "reminders": {
@@ -610,14 +608,12 @@
         "protocol": {
           "repeatProtocol": {
             "unit": "day",
-            "amount": 9
+            "amount": 3
           },
           "repeatQuestionnaire": {
             "unit": "hour",
             "unitsFromZero": [
-              36,
-              84,
-              204
+              36
             ]
           },
           "reminders": {
@@ -663,14 +659,12 @@
         "protocol": {
           "repeatProtocol": {
             "unit": "day",
-            "amount": 9
+            "amount": 3
           },
           "repeatQuestionnaire": {
             "unit": "hour",
             "unitsFromZero": [
-              60,
-              132,
-              156
+              60
             ]
           },
           "reminders": {


### PR DESCRIPTION
- Adds PDDS and 3 different audio tasks (for randomisation purposes) to STAGING_PROJECT
- `Range-info` type for PDDS is not yet supported in current aRMT release so must release and update protocol at the same time
- Some task definitions are still in test branches