### PR TITLE
Temporarily remove reminders until fully implemented

### DIFF
--- a/RADAR-MDD-CIBER-s1/protocol.json
+++ b/RADAR-MDD-CIBER-s1/protocol.json
@@ -2,9 +2,7 @@
   "version": "0.2.1",
   "schemaVersion": "0.0.2",
   "name": "RADAR MDD CIBER s1",
-  "healthIssues": [
-    "depression"
-  ],
+  "healthIssues": ["depression"],
   "protocols": [
     {
       "name": "THINC-IT",
@@ -46,9 +44,7 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            600
-          ]
+          "unitsFromZero": [600]
         },
         "reminders": {
           "unit": "day",
@@ -97,21 +93,20 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            540
-          ]
+          "unitsFromZero": [540]
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",
           "amount": 3
         }
       }
-    }, {
+    },
+    {
       "name": "RSES",
       "showIntroduction": false,
       "questionnaire": {
@@ -151,14 +146,12 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            570
-          ]
+          "unitsFromZero": [570]
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",
@@ -206,9 +199,7 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            990
-          ]
+          "unitsFromZero": [990]
         },
         "reminders": {
           "unit": "day",

--- a/RADAR-MDD-IISPV-s1/protocol.json
+++ b/RADAR-MDD-IISPV-s1/protocol.json
@@ -2,9 +2,7 @@
   "version": "0.0.1",
   "schemaVersion": "0.0.2",
   "name": "RADAR MDD IISPV s1",
-  "healthIssues": [
-    "depression"
-  ],
+  "healthIssues": ["depression"],
   "protocols": [
     {
       "name": "THINC-IT",
@@ -46,9 +44,7 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            600
-          ]
+          "unitsFromZero": [600]
         },
         "reminders": {
           "unit": "day",
@@ -97,21 +93,20 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            540
-          ]
+          "unitsFromZero": [540]
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",
           "amount": 3
         }
       }
-    }, {
+    },
+    {
       "name": "RSES",
       "showIntroduction": false,
       "questionnaire": {
@@ -151,14 +146,12 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            570
-          ]
+          "unitsFromZero": [570]
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",
@@ -206,9 +199,7 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            990
-          ]
+          "unitsFromZero": [990]
         },
         "reminders": {
           "unit": "day",

--- a/RADAR-MDD-KCL-s1/protocol.json
+++ b/RADAR-MDD-KCL-s1/protocol.json
@@ -97,8 +97,8 @@
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",
@@ -150,8 +150,8 @@
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",
@@ -252,8 +252,8 @@
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",
@@ -305,8 +305,8 @@
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",
@@ -358,8 +358,8 @@
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",

--- a/RADAR-MDD-VUmc-s1/protocol.json
+++ b/RADAR-MDD-VUmc-s1/protocol.json
@@ -2,9 +2,7 @@
   "version": "0.1.10",
   "schemaVersion": "0.0.2",
   "name": "RADAR MDD VUmc s1",
-  "healthIssues": [
-    "depression"
-  ],
+  "healthIssues": ["depression"],
   "protocols": [
     {
       "name": "THINC-IT",
@@ -46,9 +44,7 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            600
-          ]
+          "unitsFromZero": [600]
         },
         "reminders": {
           "unit": "day",
@@ -97,14 +93,12 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            540
-          ]
+          "unitsFromZero": [540]
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",
@@ -152,14 +146,12 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            570
-          ]
+          "unitsFromZero": [570]
         },
         "reminders": {
           "unit": "day",
-          "amount": 4,
-          "repeat": 1
+          "amount": 0,
+          "repeat": 0
         },
         "completionWindow": {
           "unit": "day",
@@ -207,9 +199,7 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [
-            990
-          ]
+          "unitsFromZero": [990]
         },
         "reminders": {
           "unit": "day",


### PR DESCRIPTION
Temporarily removes reminders for CNS sites until cancelling of notifications is implemented in the aRMT app (to avoid confusion for users).