### PR TITLE
Add task order for each task type shown in calendar

### DIFF
--- a/STAGING_PROJECT/protocol.json
+++ b/STAGING_PROJECT/protocol.json
@@ -10,6 +10,7 @@
         "name": "SAMPLE_INPUT_DEMO",
         "showIntroduction": false,
         "showInCalendar": false,
+        "order": 3,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "sample-field-types",
@@ -71,6 +72,7 @@
         "name": "ROMBERG",
         "showIntroduction": false,
         "showInCalendar": false,
+        "order": 0,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "romberg_test",
@@ -185,6 +187,7 @@
         "name": "2MW",
         "showIntroduction": false,
         "showInCalendar": false,
+        "order": 2,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "2MW_test",
@@ -246,6 +249,7 @@
         "name": "TANDEM WALKING",
         "showIntroduction": false,
         "showInCalendar": false,
+        "order": 1,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "tandem_walking_test",

--- a/STAGING_PROJECT/protocol.json
+++ b/STAGING_PROJECT/protocol.json
@@ -132,6 +132,7 @@
         "name": "THINC-IT",
         "showIntroduction": false,
         "showInCalendar": true,
+        "order": 2,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "thinc_it",
@@ -306,6 +307,7 @@
         "name": "PHQ8",
         "showIntroduction": false,
         "showInCalendar": true,
+        "order": 1,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "phq8",
@@ -362,6 +364,7 @@
         "name": "RSES",
         "showIntroduction": false,
         "showInCalendar": true,
+        "order": 2,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "rses",
@@ -418,6 +421,7 @@
         "name": "ESM",
         "showIntroduction": false,
         "showInCalendar": false,
+        "order": 0,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "esm",
@@ -482,6 +486,7 @@
         "name": "ESM_DEMO",
         "showIntroduction": true,
         "showInCalendar": true,
+        "order": 3,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "esm-demo",
@@ -534,6 +539,7 @@
         "name": "AUDIO",
         "showIntroduction": false,
         "showInCalendar": true,
+        "order": 3,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "audio",
@@ -586,6 +592,7 @@
         "name": "AUDIO_2",
         "showIntroduction": false,
         "showInCalendar": true,
+        "order": 3,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "audio_2",
@@ -638,6 +645,7 @@
         "name": "AUDIO_3",
         "showIntroduction": false,
         "showInCalendar": true,
+        "order": 3,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "audio_3",
@@ -690,6 +698,7 @@
         "name": "PDDS",
         "showIntroduction": false,
         "showInCalendar": true,
+        "order": 3,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "patient_determined_disease_step",
@@ -746,6 +755,7 @@
         "name": "PDQ",
         "showIntroduction": false,
         "showInCalendar": true,
+        "order": 3,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
           "name": "perceived_deficits_questionnaire",

--- a/STAGING_PROJECT/protocol.json
+++ b/STAGING_PROJECT/protocol.json
@@ -10,6 +10,7 @@
         "name": "SAMPLE_INPUT_DEMO",
         "showIntroduction": false,
         "showInCalendar": false,
+        "isDemo": true,
         "order": 3,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
@@ -490,6 +491,7 @@
         "name": "ESM_DEMO",
         "showIntroduction": true,
         "showInCalendar": true,
+        "isDemo": true,
         "order": 3,
         "questionnaire": {
           "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",

--- a/docs/protocol-schema-0.0.5.json
+++ b/docs/protocol-schema-0.0.5.json
@@ -1,0 +1,406 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "http://radar-base.org/armt/protocol/schema#",
+  "$id": "http://radar-base.org/armt/protocol/schema#",
+  "type": "object",
+  "title": "RADAR-base protocol for the aRMT app questionnaire delivery",
+  "description": "A protocol for the RADAR-base aRMT app describes what questionnaires should be proposed to participants at what time. It controls notification times, label text and the questionnaire sources. The reference questionnaire app is described on the wiki page https://radar-base.atlassian.net/wiki/spaces/RAD/pages/463241217/Protocol+Schedule.",
+  "version": "0.0.5",
+  "required": [
+    "version",
+    "schemaVersion",
+    "name",
+    "protocols"
+  ],
+  "properties": {
+    "version": {
+      "$id": "#/properties/version",
+      "type": "string",
+      "title": "Protocol version",
+      "description": "Update this version whenever the aRMT app should read any changes. Use semantic versioning for the version.",
+      "examples": [
+        "0.2.3"
+      ],
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+[0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)?$"
+    },
+    "schemaVersion": {
+      "$id": "#/properties/schemaVersion",
+      "type": "string",
+      "title": "The version of this schema",
+      "description": "The version of this schema describing the protocol structure. Use semantic versioning for the version.",
+      "default": "",
+      "examples": [
+        "0.0.2"
+      ],
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+[0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)?$"
+    },
+    "name": {
+      "$id": "#/properties/name",
+      "type": "string",
+      "title": "Protocol set name",
+      "description": "The name of the set of protocols. It should match the study that the protocol is being used in.",
+      "examples": [
+        "RADAR MDD KCL s1"
+      ]
+    },
+    "healthIssues": {
+      "$id": "#/properties/healthIssues",
+      "type": "array",
+      "title": "Health issues",
+      "description": "Study area of health issues that are covered by the questionnaire.",
+      "items": {
+        "$id": "#/properties/healthIssues/items",
+        "type": "string",
+        "title": "Health issue",
+        "default": "",
+        "examples": [
+          "depression"
+        ]
+      }
+    },
+    "protocols": {
+      "$id": "#/properties/protocols",
+      "type": "array",
+      "title": "Questionnaire protocols",
+      "description": "List of questionnaire protocols in the study protocol.",
+      "items": {
+        "$id": "#/properties/protocols/items",
+        "type": "object",
+        "title": "Questionnaire protocol",
+        "description": "Single questionnaire protocol.",
+        "required": [
+          "name",
+          "showIntroduction",
+          "questionnaire",
+          "startText",
+          "endText",
+          "warn",
+          "estimatedCompletionTime",
+          "protocol"
+        ],
+        "properties": {
+          "name": {
+            "$id": "#/properties/protocols/items/properties/name",
+            "type": "string",
+            "title": "Protocol name",
+            "examples": [
+              "PHQ8"
+            ]
+          },
+          "showIntroduction": {
+            "$id": "#/properties/protocols/items/properties/showIntroduction",
+            "type": "boolean",
+            "title": "Show an introduction",
+            "description": "True if an introduction to the questionnaire should be shown, false otherwise. The contents of the introduction are defined by the 'startText' property.",
+            "default": "",
+            "examples": [
+              false
+            ]
+          },
+          "showInCalendar": {
+            "$id": "#/properties/protocols/items/properties/showInCalendar",
+            "type": "boolean",
+            "title": "Whether the questionnaire should show up on the task calendar.",
+            "description": "True if the questionnaire should show up on the task calendar and show task information, or false, if it should be hidden (for example, for randomised questionnaires).",
+            "default": true,
+            "examples": [
+              false
+            ]
+          },          
+          "isDemo": {
+            "$id": "#/properties/protocols/items/properties/isDemo",
+            "type": "boolean",
+            "title": "Whether the questionnaire is only a demo",
+            "description": "True if the questionnaire is only a demo, so the data for the questionnaire should not be sent to the server.",
+            "default": false,
+            "examples": [
+              true
+            ]
+          },
+          "order": {
+            "$id": "#/properties/protocols/items/properties/order",
+            "type": "integer",
+            "title": "Order for showing tasks in the home page",
+            "description": "Order for choosing tasks to prioritize in the home page when multiple tasks are pending and order for showing clinical tasks, where 0 has the highest order/priority.",
+            "default": false,
+            "examples": [
+              true
+            ]
+          },
+          "questionnaire": {
+            "$id": "#/properties/protocols/items/properties/questionnaire",
+            "type": "object",
+            "title": "Questionnaire to use",
+            "description": "Reference to the questionnaire specification. This defines the questions, field type, branching logic etc.",
+            "required": [
+              "repository",
+              "name",
+              "avsc"
+            ],
+            "properties": {
+              "repository": {
+                "$id": "#/properties/protocols/items/properties/questionnaire/properties/repository",
+                "type": "string",
+                "title": "Repository URL",
+                "default": "",
+                "examples": [
+                  "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/"
+                ]
+              },
+              "name": {
+                "$id": "#/properties/protocols/items/properties/questionnaire/properties/name",
+                "type": "string",
+                "title": "Questionnaire name",
+                "description": "Name should match file name under the URL provided in the repository property.",
+                "default": "",
+                "examples": [
+                  "phq8"
+                ]
+              },
+              "avsc": {
+                "$id": "#/properties/protocols/items/properties/questionnaire/properties/avsc",
+                "type": "string",
+                "title": "Schema",
+                "description": "Avro Schema name as defined in RADAR-Schemas.",
+                "examples": [
+                  "notification"
+                ]
+              }
+            }
+          },
+          "startText": {
+            "$id": "#/properties/protocols/items/properties/startText",
+            "type": "object",
+            "title": "Start text",
+            "description": "Text shown in the app before starting a questionnaire. Enable it with the 'showIntroduction' property.",
+            "required": ["en"],
+            "patternProperties": {
+              "^[a-z][a-z](-[a-zA-Z0-9]+)*$": {"type": "string", "description": "Text in the language corresponding to property name. The property name should be a ISO 639-1 two letter language code or BCP-47 language tag.", "examples": ["en", "nl", "en-US"]}
+            },
+            "additionalProperties": false
+          },
+          "endText": {
+            "$id": "#/properties/protocols/items/properties/endText",
+            "type": "object",
+            "title": "End text",
+            "description": "Text shown in the app after finishing a questionnaire.",
+            "required": ["en"],
+            "patternProperties": {
+              "^[a-z][a-z](-[a-zA-Z0-9]+)*$": {"type": "string", "description": "Text in the language corresponding to property name. The property name should be a ISO 639-1 two letter language code or BCP-47 language tag.", "examples": ["en", "nl", "en-US"]}
+            },
+            "additionalProperties": false
+          },
+          "warn": {
+            "$id": "#/properties/protocols/items/properties/warn",
+            "type": "object",
+            "title": "Warning text",
+            "description": "Warning shown when the questionnaire has not been filled.",
+            "required": ["en"],
+            "patternProperties": {
+              "^[a-z][a-z](-[a-zA-Z0-9]+)*$": {"type": "string", "description": "Text in the language corresponding to property name. The property name should be a ISO 639-1 two letter language code or BCP-47 language tag.", "examples": ["en", "nl", "en-US"]}
+            },
+            "additionalProperties": false
+          },
+          "estimatedCompletionTime": {
+            "$id": "#/properties/protocols/items/properties/estimatedCompletionTime",
+            "type": "integer",
+            "title": "Estimated completion time",
+            "description": "Estimated completion time in minutes.",
+            "examples": [
+              1
+            ]
+          },
+          
+          "protocol": {
+            "$id": "#/properties/protocols/items/properties/protocol",
+            "type": "object",
+            "title": "Questionnaire protocol",
+            "description": "Protocol including schedule for the questionnaire.",
+            "required": [
+              "repeatProtocol",
+              "repeatQuestionnaire",
+              "reminders"
+            ],
+            "properties": {
+              "repeatProtocol": {
+                "$id": "#/properties/protocols/items/properties/protocol/properties/repeatProtocol",
+                "type": "object",
+                "title": "Protocol repetition",
+                "description": "How frequently the protocol should be repeated for each participant.",
+                "required": [
+                  "unit",
+                  "amount"
+                ],
+                "default": {
+                  "unit": "day",
+                  "amount": 7
+                },
+                "properties": {
+                  "unit": {
+                    "$id": "#/properties/protocols/items/properties/protocol/properties/repeatProtocol/properties/unit",
+                    "type": "string",
+                    "enum": ["min", "hour", "day", "week", "month", "year"],
+                    "title": "Amount unit",
+                    "description": "Duration unit attached to the amount property in repeatProtocol.",
+                    "examples": [
+                      "day"
+                    ]
+                  },
+                  "amount": {
+                    "$id": "#/properties/protocols/items/properties/protocol/properties/repeatProtocol/properties/amount",
+                    "type": "integer",
+                    "title": "Amount of time",
+                    "description": "Modified by the unit property in repeatProtocol.",
+                    "examples": [
+                      7
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "repeatQuestionnaire": {
+                "$id": "#/properties/protocols/items/properties/protocol/properties/repeatQuestionnaire",
+                "type": "object",
+                "title": "Questionnaire repetitions",
+                "description": "What time of day questionnaires should be posed. The day that questionnaires are posed are specified with repeatProtocol, the local time is defined by this repeatQuestionnaire (units offset from repeat from midnight repeatProtocol day).",
+                "required": [
+                  "unit",
+                  "unitsFromZero"
+                ],
+                "properties": {
+                  "unit": {
+                    "$id": "#/properties/protocols/items/properties/protocol/properties/repeatQuestionnaire/properties/unit",
+                    "type": "string",
+                    "enum": ["min", "hour", "day"],
+                    "title": "Amount unit",
+                    "description": "Duration unit attached to the unitsFromZero property in repeatQuestionnaire.",
+                    "examples": [
+                      "min"
+                    ]
+                  },
+                  "unitsFromZero": {
+                    "$id": "#/properties/protocols/items/properties/protocol/properties/repeatQuestionnaire/properties/unitsFromZero",
+                    "type": "array",
+                    "title": "Times starting at midnight",
+                    "description": "Times, starting from midnight, that a protocol should be suggested. The date of the midnight in question is determined by repeatProtocol.",
+                    "items": {
+                      "$id": "#/properties/protocols/items/properties/protocol/properties/repeatQuestionnaire/properties/unitsFromZero/items",
+                      "type": "integer",
+                      "title": "Amount of time",
+                      "description": "Modified by the unit property in repeatQuestionnaire",
+                      "examples": [
+                        600
+                      ]
+                    }
+                  }
+                }
+              },
+              "clinicalProtocol": {
+                "$id": "#/properties/protocols/items/properties/protocol/properties/clinicalProtocol",
+                "type": "object",
+                "title": "Clinical protocol",
+                "description": "Defines repetitions of the protocol after a clinical visit.",
+                "required": [
+                  "repeatAfterClinicVisit"
+                ],
+                "properties": {
+                  "requiresInClinicCompletion": {
+                    "$id": "#/properties/protocols/items/properties/protocol/properties/repeatQuestionnaire",
+                    "type": "boolean",
+                    "title": "Requires in-clinic completion.",
+                    "description": "Whether the test should be performed during a clinical visit.",
+                    "examples": [
+                      true
+                    ]
+                  },
+                  "repeatAfterClinicVisit": {
+                    "$id": "#/properties/protocols/items/properties/protocol/properties/repeatQuestionnaire",
+                    "type": "object",
+                    "title": "Test repetitions",
+                    "description": "When to repeat the test.",
+                    "required": [
+                      "unit",
+                      "unitsFromZero"
+                    ],
+                    "properties": {
+                      "unit": {
+                        "$id": "#/properties/protocols/items/properties/protocol/properties/repeatQuestionnaire/properties/unit",
+                        "type": "string",
+                        "enum": ["min", "hour", "day"],
+                        "title": "Amount unit",
+                        "description": "Duration unit attached to the unitsFromZero property in repeatAfterClinicVisit.",
+                        "examples": [
+                          "min"
+                        ]
+                      },
+                      "unitsFromZero": {
+                        "$id": "#/properties/protocols/items/properties/protocol/properties/repeatQuestionnaire/properties/unitsFromZero",
+                        "type": "array",
+                        "title": "Times",
+                        "description": "Times, starting from clinic visit, that a protocol should start.",
+                        "items": {
+                          "$id": "#/properties/protocols/items/properties/protocol/properties/repeatQuestionnaire/properties/unitsFromZero/items",
+                          "type": "integer",
+                          "title": "Amount of time",
+                          "description": "Modified by the unit property in repeatAfterClinicVisit",
+                          "examples": [
+                            600
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "reminders": {
+                "$id": "#/properties/protocols/items/properties/protocol/properties/reminders",
+                "type": "object",
+                "title": "Reminder schedule",
+                "description": "When and how often to remind participants that a questionnairie still has to be filled out.",
+                "required": [
+                  "unit",
+                  "amount",
+                  "repeat"
+                ],
+                "properties": {
+                  "unit": {
+                    "$id": "#/properties/protocols/items/properties/protocol/properties/reminders/properties/unit",
+                    "type": "string",
+                    "enum": ["min", "hour", "day", "week", "month", "year"],
+                    "title": "Amount unit",
+                    "description": "Duration unit modifing the amount property in reminders.",
+                    "examples": [
+                      "day"
+                    ]
+                  },
+                  "amount": {
+                    "$id": "#/properties/protocols/items/properties/protocol/properties/reminders/properties/amount",
+                    "type": "integer",
+                    "title": "Amount of time",
+                    "description": "Time to wait after the previous notification. Modified by the unit property in reminders.",
+                    "examples": [
+                      0
+                    ]
+                  },
+                  "repeat": {
+                    "$id": "#/properties/protocols/items/properties/protocol/properties/reminders/properties/repeat",
+                    "type": "integer",
+                    "title": "Repetitions",
+                    "description": "Number of reminders to send.",
+                    "default": 0,
+                    "examples": [
+                      0
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/protocol-schema-0.0.5.json
+++ b/docs/protocol-schema-0.0.5.json
@@ -122,9 +122,9 @@
             "type": "integer",
             "title": "Order for showing tasks in the home page",
             "description": "Order for choosing tasks to prioritize in the home page when multiple tasks are pending and order for showing clinical tasks, where 0 has the highest order/priority.",
-            "default": false,
+            "default": 0,
             "examples": [
-              true
+              0
             ]
           },
           "questionnaire": {

--- a/docs/protocol-schema.json
+++ b/docs/protocol-schema.json
@@ -1,1 +1,1 @@
-protocol-schema-0.0.4.json
+protocol-schema-0.0.5.json


### PR DESCRIPTION
Changes to STAGING_PROJECT protocol

- Adds task order for each task type shown in calendar to give ESM and PHQ8 higher priority
- Adds task order for clinical tasks to show clinical tasks in a certain order
- Adds `isDemo` property to demo tasks