### PR TITLE
Update COVID followup questionnaire in KCL MDD

### DIFF
--- a/RADAR-MDD-KCL-s1/protocol.json
+++ b/RADAR-MDD-KCL-s1/protocol.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.1",
+  "version": "0.4.2",
   "schemaVersion": "0.0.2",
   "name": "RADAR MDD KCL s1",
   "healthIssues": ["depression"],

--- a/RADAR-MDD-KCL-s1/protocol.json
+++ b/RADAR-MDD-KCL-s1/protocol.json
@@ -545,14 +545,14 @@
       }
     },
     {
-      "name": "CNS_COVID19_FOLLOWUP",
+      "name": "CNS_COVID19_FOLLOWUP_V2",
       "showIntroduction": false,
       "showInCalendar": true,
       "isDemo": false,
       "order": 2,
       "questionnaire": {
         "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "cns_covid19_followup",
+        "name": "cns_covid19_followup_v2",
         "avsc": "questionnaire"
       },
       "startText": {

--- a/RADAR-MDD-KCL-s1/protocol.json
+++ b/RADAR-MDD-KCL-s1/protocol.json
@@ -545,7 +545,7 @@
       }
     },
     {
-      "name": "CNS_COVID19_FOLLOWUP_V2",
+      "name": "CNS_COVID19_FOLLOWUP",
       "showIntroduction": false,
       "showInCalendar": true,
       "isDemo": false,


### PR DESCRIPTION
- Replaces current CNS_COVID19_FOLLOWUP questionnaire with new version (v2) with additional questions