### PR TITLE
Update COVID followup questionnaire in KCL MDD

### DIFF
--- a/RADAR-MDD-KCL-s1/protocol.json
+++ b/RADAR-MDD-KCL-s1/protocol.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.2",
+  "version": "0.4.3",
   "schemaVersion": "0.0.2",
   "name": "RADAR MDD KCL s1",
   "healthIssues": ["depression"],
@@ -552,7 +552,7 @@
       "order": 2,
       "questionnaire": {
         "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
-        "name": "cns_covid19_followup_v2",
+        "name": "cns_covid19_followup_v3",
         "avsc": "questionnaire"
       },
       "startText": {


### PR DESCRIPTION
- Replaces current CNS_COVID19_FOLLOWUP (v2) questionnaire with a new version (v3) with additional questions (1 additional question asking about the lockdown experience)

https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/cns_covid19_followup_v3/cns_covid19_followup_v3_armt.json