### PR TITLE
Add RADAR AIMS protocol

### DIFF
--- a/RADAR-AIIMS-2-TRIALS-KCL-s1/protocol.json
+++ b/RADAR-AIIMS-2-TRIALS-KCL-s1/protocol.json
@@ -327,7 +327,7 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [1110]
+          "unitsFromZero": [6870]
         },
         "reminders": {
           "unit": "day",

--- a/RADAR-AIIMS-2-TRIALS-KCL-s1/protocol.json
+++ b/RADAR-AIIMS-2-TRIALS-KCL-s1/protocol.json
@@ -312,12 +312,12 @@
         "es": ""
       },
       "warn": {
-        "en": "Find a quiet space.",
-        "it": "Trova uno spazio tranquillo.",
-        "nl": "Zoek een stille ruimte.",
-        "da": "Find et roligt sted.",
-        "de": "Suchen Sie sich einen ruhigen Platz.",
-        "es": "Encuentra un espacio tranquilo."
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
       },
       "estimatedCompletionTime": 3,
       "protocol": {
@@ -368,12 +368,12 @@
         "es": ""
       },
       "warn": {
-        "en": "Find a quiet space.",
-        "it": "Trova uno spazio tranquillo.",
-        "nl": "Zoek een stille ruimte.",
-        "da": "Find et roligt sted.",
-        "de": "Suchen Sie sich einen ruhigen Platz.",
-        "es": "Encuentra un espacio tranquilo."
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
       },
       "estimatedCompletionTime": 3,
       "protocol": {

--- a/RADAR-AIIMS-2-TRIALS-KCL-s1/protocol.json
+++ b/RADAR-AIIMS-2-TRIALS-KCL-s1/protocol.json
@@ -11,7 +11,7 @@
       "isDemo": false,
       "order": 0,
       "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
         "name": "technology_usage",
         "avsc": "notification"
       },
@@ -53,6 +53,10 @@
           "unit": "day",
           "amount": 0,
           "repeat": 0
+        },
+        "completionWindow": {
+          "unit": "min",
+          "amount": 960
         }
       }
     },
@@ -63,7 +67,7 @@
       "isDemo": false,
       "order": 1,
       "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
         "name": "regular_activities",
         "avsc": "questionnaire"
       },
@@ -107,8 +111,8 @@
           "repeat": 0
         },
         "completionWindow": {
-          "unit": "day",
-          "amount": 3
+          "unit": "min",
+          "amount": 960
         }
       }
     },
@@ -119,7 +123,7 @@
       "isDemo": false,
       "order": 2,
       "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
         "name": "nonregular_activities",
         "avsc": "questionnaire"
       },
@@ -163,8 +167,8 @@
           "repeat": 0
         },
         "completionWindow": {
-          "unit": "day",
-          "amount": 3
+          "unit": "min",
+          "amount": 960
         }
       }
     },
@@ -175,7 +179,7 @@
       "isDemo": false,
       "order": 0,
       "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
         "name": "autism_symptoms",
         "avsc": "questionnaire"
       },
@@ -231,7 +235,7 @@
       "isDemo": false,
       "order": 5,
       "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
         "name": "sleep_quality",
         "avsc": "questionnaire"
       },
@@ -267,12 +271,16 @@
         },
         "repeatQuestionnaire": {
           "unit": "min",
-          "unitsFromZero": [510]
+          "unitsFromZero": [1950]
         },
         "reminders": {
           "unit": "day",
           "amount": 0,
           "repeat": 0
+        },
+        "completionWindow": {
+          "unit": "min",
+          "amount": 930
         }
       }
     },
@@ -283,7 +291,7 @@
       "isDemo": false,
       "order": 3,
       "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
         "name": "adhd_symptoms",
         "avsc": "questionnaire"
       },
@@ -328,7 +336,7 @@
         },
         "completionWindow": {
           "unit": "day",
-          "amount": 7
+          "amount": 1
         }
       }
     },
@@ -339,7 +347,7 @@
       "isDemo": false,
       "order": 3,
       "questionnaire": {
-        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
         "name": "user_feedback",
         "avsc": "questionnaire"
       },

--- a/RADAR-AIIMS-2-TRIALS-KCL-s1/protocol.json
+++ b/RADAR-AIIMS-2-TRIALS-KCL-s1/protocol.json
@@ -1,7 +1,7 @@
 {
   "version": "0.0.1",
   "schemaVersion": "0.0.2",
-  "name": "RADAR AIMS2T KCL s1",
+  "name": "RADAR AIIMS-2 TRIALS KCL s1",
   "healthIssues": ["autism"],
   "protocols": [
     {

--- a/RADAR-AIMS2T-KCL-s1/protocol.json
+++ b/RADAR-AIMS2T-KCL-s1/protocol.json
@@ -1,0 +1,392 @@
+{
+  "version": "0.0.1",
+  "schemaVersion": "0.0.2",
+  "name": "RADAR AIMS2T KCL s1",
+  "healthIssues": ["autism"],
+  "protocols": [
+    {
+      "name": "Technology Usage",
+      "showIntroduction": false,
+      "showInCalendar": true,
+      "isDemo": false,
+      "order": 0,
+      "questionnaire": {
+        "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "name": "technology_usage",
+        "avsc": "notification"
+      },
+      "startText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "endText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "warn": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "estimatedCompletionTime": 1,
+      "protocol": {
+        "repeatProtocol": {
+          "unit": "year",
+          "amount": 9999
+        },
+        "repeatQuestionnaire": {
+          "unit": "min",
+          "unitsFromZero": [480]
+        },
+        "reminders": {
+          "unit": "day",
+          "amount": 0,
+          "repeat": 0
+        }
+      }
+    },
+    {
+      "name": "Regular Activities",
+      "showIntroduction": false,
+      "showInCalendar": true,
+      "isDemo": false,
+      "order": 1,
+      "questionnaire": {
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "name": "regular_activities",
+        "avsc": "questionnaire"
+      },
+      "startText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "endText": {
+        "en": "Thank you for taking the time today.",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "warn": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "estimatedCompletionTime": 2,
+      "protocol": {
+        "repeatProtocol": {
+          "unit": "year",
+          "amount": 9999
+        },
+        "repeatQuestionnaire": {
+          "unit": "min",
+          "unitsFromZero": [480]
+        },
+        "reminders": {
+          "unit": "day",
+          "amount": 0,
+          "repeat": 0
+        },
+        "completionWindow": {
+          "unit": "day",
+          "amount": 3
+        }
+      }
+    },
+    {
+      "name": "Nonregular Activities",
+      "showIntroduction": false,
+      "showInCalendar": true,
+      "isDemo": false,
+      "order": 2,
+      "questionnaire": {
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "name": "nonregular_activities",
+        "avsc": "questionnaire"
+      },
+      "startText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "endText": {
+        "en": "Thank you for taking the time today.",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "warn": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "estimatedCompletionTime": 3,
+      "protocol": {
+        "repeatProtocol": {
+          "unit": "year",
+          "amount": 9999
+        },
+        "repeatQuestionnaire": {
+          "unit": "min",
+          "unitsFromZero": [480]
+        },
+        "reminders": {
+          "unit": "day",
+          "amount": 0,
+          "repeat": 0
+        },
+        "completionWindow": {
+          "unit": "day",
+          "amount": 3
+        }
+      }
+    },
+    {
+      "name": "Autism Symptoms",
+      "showIntroduction": false,
+      "showInCalendar": true,
+      "isDemo": false,
+      "order": 0,
+      "questionnaire": {
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "name": "autism_symptoms",
+        "avsc": "questionnaire"
+      },
+      "startText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "endText": {
+        "en": "Thank you for taking the time today.",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "warn": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "estimatedCompletionTime": 1,
+      "protocol": {
+        "repeatProtocol": {
+          "unit": "year",
+          "amount": 9999
+        },
+        "repeatQuestionnaire": {
+          "unit": "min",
+          "unitsFromZero": [12120, 32280]
+        },
+        "reminders": {
+          "unit": "day",
+          "amount": 0,
+          "repeat": 0
+        },
+        "completionWindow": {
+          "unit": "day",
+          "amount": 1
+        }
+      }
+    },
+    {
+      "name": "Sleep Quality",
+      "showIntroduction": true,
+      "showInCalendar": true,
+      "isDemo": true,
+      "order": 5,
+      "questionnaire": {
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "name": "sleep_quality",
+        "avsc": "questionnaire"
+      },
+      "startText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "endText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "warn": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "estimatedCompletionTime": 3,
+      "protocol": {
+        "repeatProtocol": {
+          "unit": "day",
+          "amount": 1
+        },
+        "repeatQuestionnaire": {
+          "unit": "min",
+          "unitsFromZero": [510]
+        },
+        "reminders": {
+          "unit": "day",
+          "amount": 0,
+          "repeat": 0
+        }
+      }
+    },
+    {
+      "name": "ADHD Symptoms",
+      "showIntroduction": false,
+      "showInCalendar": true,
+      "isDemo": false,
+      "order": 3,
+      "questionnaire": {
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "name": "adhd_symptoms",
+        "avsc": "questionnaire"
+      },
+      "startText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "endText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "warn": {
+        "en": "Find a quiet space.",
+        "it": "Trova uno spazio tranquillo.",
+        "nl": "Zoek een stille ruimte.",
+        "da": "Find et roligt sted.",
+        "de": "Suchen Sie sich einen ruhigen Platz.",
+        "es": "Encuentra un espacio tranquilo."
+      },
+      "estimatedCompletionTime": 3,
+      "protocol": {
+        "repeatProtocol": {
+          "unit": "day",
+          "amount": 4
+        },
+        "repeatQuestionnaire": {
+          "unit": "min",
+          "unitsFromZero": [1110]
+        },
+        "reminders": {
+          "unit": "day",
+          "amount": 0,
+          "repeat": 0
+        },
+        "completionWindow": {
+          "unit": "day",
+          "amount": 7
+        }
+      }
+    },
+    {
+      "name": "User Feedback",
+      "showIntroduction": false,
+      "showInCalendar": true,
+      "isDemo": false,
+      "order": 3,
+      "questionnaire": {
+        "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",
+        "name": "user_feedback",
+        "avsc": "questionnaire"
+      },
+      "startText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "endText": {
+        "en": "",
+        "it": "",
+        "nl": "",
+        "da": "",
+        "de": "",
+        "es": ""
+      },
+      "warn": {
+        "en": "Find a quiet space.",
+        "it": "Trova uno spazio tranquillo.",
+        "nl": "Zoek een stille ruimte.",
+        "da": "Find et roligt sted.",
+        "de": "Suchen Sie sich einen ruhigen Platz.",
+        "es": "Encuentra un espacio tranquilo."
+      },
+      "estimatedCompletionTime": 3,
+      "protocol": {
+        "repeatProtocol": {
+          "unit": "year",
+          "amount": 9999
+        },
+        "repeatQuestionnaire": {
+          "unit": "min",
+          "unitsFromZero": [42360]
+        },
+        "reminders": {
+          "unit": "day",
+          "amount": 0,
+          "repeat": 0
+        },
+        "completionWindow": {
+          "unit": "day",
+          "amount": 7
+        }
+      }
+    }
+  ]
+}

--- a/RADAR-AIMS2T-KCL-s1/protocol.json
+++ b/RADAR-AIMS2T-KCL-s1/protocol.json
@@ -226,9 +226,9 @@
     },
     {
       "name": "Sleep Quality",
-      "showIntroduction": true,
+      "showIntroduction": false,
       "showInCalendar": true,
-      "isDemo": true,
+      "isDemo": false,
       "order": 5,
       "questionnaire": {
         "repository": "https://raw.githubusercontent.com/RADAR-CNS/RADAR-REDCap-aRMT-Definitions/aims/questionnaires/",


### PR DESCRIPTION
- Add RADAR-AIIMS-2-TRIALS-KCL-s1 protocol (schedule sent by Izzy from the clinical team)

_Currently the questionnaire definition branch is set to `aims` since the [PR](https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/pull/138) hasn't been merged. Will change this once it has been merged._