### PR TITLE
Add a dummy ers to copd

### DIFF
--- a/RALPMH-COPD-Lon-s1/protocol.json
+++ b/RALPMH-COPD-Lon-s1/protocol.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "schemaVersion": "0.0.2",
   "name": "RALPMH COPD Project",
   "healthIssues": [
@@ -733,6 +733,57 @@
           }
         }
       }
-    }
+    },
+    {
+        "name": "ers",
+        "showIntroduction": true,
+        "questionnaire": {
+          "repository": "https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/",
+          "name": "ers",
+          "avsc": "questionnaire"
+        },
+        "startText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "endText": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "warn": {
+          "en": "",
+          "it": "",
+          "nl": "",
+          "da": "",
+          "de": "",
+          "es": ""
+        },
+        "estimatedCompletionTime": 3,
+        "protocol": {
+          "repeatProtocol": {
+            "unit": "year",
+            "amount": 9999
+          },
+          "repeatQuestionnaire": {
+            "unit": "year",
+            "unitsFromZero": [
+              9999
+            ]
+          },
+          "reminders": {
+            "unit": "day",
+            "amount": 0,
+            "repeat": 0
+          }
+        }
+      }
   ]
 }


### PR DESCRIPTION
- so the definitions are stored in the app when the questionnaire is triggered in realtime
- should be fixed by https://github.com/RADAR-base/RADAR-Questionnaire/pull/1429 and this should be removed once that is released.